### PR TITLE
Export Resource type and correct use TContext in usePermissions

### DIFF
--- a/docs/content/docs/7.recipes/3.user-augmentation.md
+++ b/docs/content/docs/7.recipes/3.user-augmentation.md
@@ -12,7 +12,7 @@ Make `useConvexAuth().user` understand app-specific claims like `role` or `strip
 ## Add Module Augmentation
 
 ```ts [app/types/convex-user.d.ts]
-declare module 'better-convex-nuxt/dist/runtime/utils/types' {
+declare module 'better-convex-nuxt' {
   interface ConvexUser {
     role?: 'admin' | 'member' | 'viewer'
     stripeCustomerId?: string

--- a/src/module.ts
+++ b/src/module.ts
@@ -26,6 +26,7 @@ import type { LogLevel } from './runtime/utils/logger'
 export type { LogLevel } from './runtime/utils/logger'
 export type { ConvexAuthPageMeta } from './runtime/utils/auth-route-protection'
 export type { Resource } from './runtime/composables/usePermissions'
+export type { ConvexUser } from './runtime/devtools/types'
 
 const logger = useLogger('better-convex-nuxt')
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -25,6 +25,7 @@ import type { LogLevel } from './runtime/utils/logger'
 // Re-export LogLevel from logger for external use
 export type { LogLevel } from './runtime/utils/logger'
 export type { ConvexAuthPageMeta } from './runtime/utils/auth-route-protection'
+export type { Resource } from './runtime/composables/usePermissions'
 
 const logger = useLogger('better-convex-nuxt')
 

--- a/src/runtime/composables/usePermissions.ts
+++ b/src/runtime/composables/usePermissions.ts
@@ -53,8 +53,8 @@ export interface Resource {
  * Check permission function signature.
  * User provides this from their permissions.config.ts
  */
-export type CheckPermissionFn<TPermission extends string = string> = (
-  ctx: { role: string; userId: string } | null,
+export type CheckPermissionFn<TPermission extends string = string, TContext extends PermissionContext = PermissionContext> = (
+  ctx: TContext | null,
   permission: TPermission,
   resource?: Resource,
 ) => boolean
@@ -64,12 +64,12 @@ export type CheckPermissionFn<TPermission extends string = string> = (
  */
 export interface CreatePermissionsOptions<
   TPermission extends string = string,
-  _TContext extends PermissionContext = PermissionContext,
+  TContext extends PermissionContext = PermissionContext,
 > {
   /** Convex query that returns permission context (role, userId, orgId, etc.) */
   query: FunctionReference<'query'>
   /** Permission checking function from permissions.config.ts */
-  checkPermission: CheckPermissionFn<TPermission>
+  checkPermission: CheckPermissionFn<TPermission, TContext>
 }
 
 /**
@@ -161,10 +161,7 @@ export function createPermissions<
     const ctx = computed(() => {
       const context = permissionContext.value as TContext | null
       if (!context?.role) return null
-      return {
-        role: context.role,
-        userId: context.userId,
-      }
+      return context
     })
 
     // Permission check function (returns reactive ComputedRef)


### PR DESCRIPTION
- Export Resource type for declare custom types 
- Use TContext for correct type annotation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `Resource` type is now publicly exported for use throughout your applications.
  * Permission-checking API now supports flexible context structures, allowing you to define custom permission contexts beyond the standard role and user ID model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->