### PR TITLE
Export ConvexUser from the module entrypoint

### DIFF
--- a/docs/content/docs/4.auth-security/1.authentication.md
+++ b/docs/content/docs/4.auth-security/1.authentication.md
@@ -1094,7 +1094,7 @@ Use `import type { AppAuth }` only. Do not runtime-import your server auth insta
 `useConvexAuth().user` is typed as `ConvexUser`. You can extend it with TypeScript module augmentation so app-specific fields like `role`, `authId`, or `organizationId` are recognized by your editor and type checker.
 
 ```ts [app/types/convex-user.d.ts]
-declare module 'better-convex-nuxt/dist/runtime/utils/types' {
+declare module 'better-convex-nuxt' {
   interface ConvexUser {
     role?: 'owner' | 'admin' | 'member' | 'viewer'
     authId?: string

--- a/docs/content/docs/7.recipes/3.user-augmentation.md
+++ b/docs/content/docs/7.recipes/3.user-augmentation.md
@@ -12,7 +12,7 @@ Make `useConvexAuth().user` understand app-specific claims like `role` or `strip
 ## Add Module Augmentation
 
 ```ts [app/types/convex-user.d.ts]
-declare module 'better-convex-nuxt/dist/runtime/utils/types' {
+declare module 'better-convex-nuxt' {
   interface ConvexUser {
     role?: 'admin' | 'member' | 'viewer'
     stripeCustomerId?: string

--- a/src/module.ts
+++ b/src/module.ts
@@ -39,6 +39,7 @@ import type { LogLevel } from './runtime/utils/logger'
 // Re-export LogLevel from logger for external use
 export type { LogLevel } from './runtime/utils/logger'
 export type { ConvexAuthPageMeta } from './runtime/utils/auth-route-protection'
+export type { ConvexUser } from './runtime/utils/types'
 
 const logger = useLogger('better-convex-nuxt')
 

--- a/test/unit/use-convex-user-types.test.ts
+++ b/test/unit/use-convex-user-types.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import type { ConvexUser } from '../../src/module'
 import type { ConvexUserState } from '../../src/runtime/composables'
 
 type IsEqual<A, B> =
@@ -19,6 +20,7 @@ type _ProjectionStateHasProfile = Assert<
 type _BetterAuthStateHasProfile = Assert<
   IsEqual<Extract<UserState, { source: 'better-auth' }>['data'], Profile>
 >
+type _ModuleEntrypointExportsConvexUser = Assert<IsEqual<ConvexUser['id'], string>>
 
 describe('useConvexUser type contracts', () => {
   it('keeps source and data correlated through state', () => {


### PR DESCRIPTION
## Summary

- Export `ConvexUser` from the package module entrypoint so consumers can augment it without importing a deep runtime path.
- Update ConvexUser augmentation docs to target `better-convex-nuxt`.
- Add a type contract proving the module entrypoint exports `ConvexUser`.

## Validation

- `pnpm exec oxfmt --check src/module.ts test/unit/use-convex-user-types.test.ts test/fixtures/consumer-smoke/composables/usePublicApiSurfaceContracts.ts docs/content/docs/7.recipes/3.user-augmentation.md docs/content/docs/4.auth-security/1.authentication.md`
- `pnpm run check:api-surface-docs`
- `pnpm run check:package-exports`
- `pnpm run check:consumer-smoke`
- `pnpm exec vitest run --project=unit test/unit/use-convex-user-types.test.ts`
- `pnpm run test:types`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `ConvexUser` is now available from the package entrypoint, making it easier to use in TypeScript projects.
  * Updated the documented augmentation examples to use the main module path.

* **Documentation**
  * Refreshed authentication and user-augmentation guides to show the recommended TypeScript setup.

* **Tests**
  * Added a type-level check to verify the exposed user type includes the expected `id` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->