### PR TITLE
Preserve legacy demo user role data

### DIFF
--- a/demo/convex/schema.ts
+++ b/demo/convex/schema.ts
@@ -1,6 +1,8 @@
 import { defineSchema, defineTable } from 'convex/server'
 import { v } from 'convex/values'
 
+const legacyUserRole = v.union(v.literal('admin'), v.literal('member'), v.literal('viewer'))
+
 export default defineSchema({
   // ============================================
   // USERS - Simplified for Labs (no organizations)
@@ -10,6 +12,8 @@ export default defineSchema({
     displayName: v.optional(v.string()),
     email: v.optional(v.string()),
     avatarUrl: v.optional(v.string()),
+    // Existing production documents still carry this retired field.
+    role: v.optional(legacyUserRole),
     createdAt: v.number(),
     updatedAt: v.number(),
   })


### PR DESCRIPTION
Keeps the retired user role field optional in the Convex demo schema so existing production documents remain valid during deployment. Runtime authorization does not read this legacy field.