### PR TITLE
Pin packed probe package manager

### DIFF
--- a/scripts/package-check/probes.mjs
+++ b/scripts/package-check/probes.mjs
@@ -31,6 +31,7 @@ export function probeRootEntry(ctx) {
     name: 'root-entry-probe',
     private: true,
     type: 'module',
+    packageManager: packageJson.packageManager,
     devDependencies: {
       ...packageJson.peerDependencies,
       'better-convex-nuxt': `file:${ctx.tarballPath}`,


### PR DESCRIPTION
The isolated root-entry probe now uses the repository's pnpm 10 packageManager declaration instead of letting Corepack download pnpm 11, which dropped the supported Node 22.12 baseline. The full packed-entry gate passes locally.